### PR TITLE
feat: add agent authentication via X-Agent-Id header

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet *)",
+      "Bash(TEST_BASE_URL=* dotnet *)",
+      "Bash(HEADED=* TEST_BASE_URL=* dotnet *)",
+      "Bash(TEST_BASE_URL=* timeout * dotnet *)",
+      "Bash(timeout * dotnet *)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(curl *)",
+      "Bash(timeout * curl *)",
+      "Bash(pkill *)",
+      "Bash(pgrep *)",
+      "Bash(kill *)",
+      "Bash(lsof *)",
+      "Bash(smcat *)",
+      "Bash(xmllint *)",
+      "Bash(.specify/scripts/bash/*)",
+      "WebFetch(domain:data-star.dev)",
+      "WebFetch(domain:www.nuget.org)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:playwright.dev)",
+      "WebFetch(domain:lanayx.github.io)",
+      "WebSearch",
+      "mcp__plugin_context7_context7__resolve-library-id",
+      "mcp__plugin_context7_context7__query-docs"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 .idea/
 packages/
 BenchmarkDotNet.Artifacts/
+
+# AI
+.claude/settings.local.json

--- a/docs/auth.scxml
+++ b/docs/auth.scxml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" initial="AwaitingLogin">
+<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" name="TicTacToeAuth" initial="AwaitingLogin">
 
   <!--
     Authentication Child State Machine
     Models cookie-based authentication.
     Invoked from the main statechart (statechart.scxml).
+
+    Validated for Frank.Cli 7.3.0 (frank statechart parse/validate).
   -->
 
   <state id="AwaitingLogin">

--- a/docs/game.scxml
+++ b/docs/game.scxml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" initial="Playing">
+<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" name="TicTacToeGame" initial="Playing">
 
   <!--
     Game Child State Machine (single game instance)
     Models a single tic-tac-toe game from creation to disposal.
+    This is a TEMPLATE: the GameSupervisor creates runtime instances.
     Multiple instances may run concurrently, one per game board.
     Invoked from the main statechart (statechart.scxml).
 
@@ -11,7 +12,22 @@
       - GamePlay: turn-by-turn game progression
       - PlayerIdentity: player role assignment
 
+    State alignment with MoveResult DU:
+      XTurn     -> MoveResult.XTurn
+      OTurn     -> MoveResult.OTurn
+      Won       -> MoveResult.Won
+      Draw      -> MoveResult.Draw
+      MoveError -> MoveResult.Error (transient, returns via history)
+      Disposed  -> removed from GameSupervisor store
+
     Lifecycle events (dispose, reset, timeout) exit the entire game.
+
+    Note: ECMAScript guard functions (wouldWin, wouldFillBoard,
+    isParticipant, hasActivity) and <assign> actions are out of scope
+    for the Frank.Cli statechart parser (silently skipped). The guards
+    are preserved as string expressions in the AST for documentation.
+
+    Validated for Frank.Cli 7.3.0 (frank statechart parse/validate).
   -->
 
   <datamodel>

--- a/docs/statechart.scxml
+++ b/docs/statechart.scxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" initial="Unauthenticated">
+<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" name="TicTacToeApp" initial="Unauthenticated">
 
   <!--
     TicTacToe Application Statechart
@@ -10,7 +10,12 @@
       3. Participate in games (child state machine: game.scxml)
 
     Auth and Game are invoked as child state machines.
-    Multiple game instances may be active concurrently.
+    The game.scxml child machine is a TEMPLATE for a single game instance;
+    the GameSupervisor creates runtime instances from this template.
+    Multiple game instances may be active concurrently, but concurrent
+    participation is managed at runtime, not modeled in SCXML.
+
+    Validated for Frank.Cli 7.3.0 (frank statechart parse/validate).
   -->
 
   <state id="Unauthenticated">

--- a/src/TicTacToe.Engine/TicTacToe.Engine.fsproj
+++ b/src/TicTacToe.Engine/TicTacToe.Engine.fsproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
   </ItemGroup>
 
 </Project>

--- a/src/TicTacToe.Web/Auth.fs
+++ b/src/TicTacToe.Web/Auth.fs
@@ -145,13 +145,41 @@ type GameUserClaimsTransformation(httpContextAccessor: IHttpContextAccessor, log
             [||]
 
     /// <summary>
-    /// Implementation of IClaimsTransformation that ensures users have
-    /// appropriate identification claims for the Tic Tac Toe application.
+    /// Tries to extract an agent identity from the X-Agent-Id header.
+    /// Returns Some(ClaimsPrincipal) if the header is present and non-empty.
     /// </summary>
+    let tryCreateAgentPrincipal () =
+        try
+            let context = httpContextAccessor.HttpContext
+            if isNull context then None
+            else
+                match context.Request.Headers.TryGetValue("X-Agent-Id") with
+                | true, values ->
+                    let agentId = values.ToString()
+                    if String.IsNullOrWhiteSpace(agentId) then None
+                    else
+                        log.LogInformation("Agent authentication via X-Agent-Id: {AgentId}", agentId)
+                        let claims = [|
+                            Claim(ClaimTypes.UserId, agentId)
+                            Claim(ClaimTypes.Created, getTimestamp())
+                            Claim(ClaimTypes.LastVisit, getTimestamp())
+                        |]
+                        let identity = ClaimsIdentity(claims, "TicTacToe.Agent")
+                        Some(ClaimsPrincipal(identity))
+                | _ -> None
+        with ex ->
+            log.LogWarning(ex, "Error checking X-Agent-Id header")
+            None
+
     interface IClaimsTransformation with
         member _.TransformAsync(principal: ClaimsPrincipal) =
             task {
                 try
+                    // Check for agent identity via X-Agent-Id header first
+                    match tryCreateAgentPrincipal() with
+                    | Some agentPrincipal -> return agentPrincipal
+                    | None ->
+
                     // Log entry point with any existing user ID
                     if not (isNull log) then
                         let existingId = principal.FindClaimValue(ClaimTypes.UserId)

--- a/src/TicTacToe.Web/Auth.fs
+++ b/src/TicTacToe.Web/Auth.fs
@@ -176,9 +176,11 @@ type GameUserClaimsTransformation(httpContextAccessor: IHttpContextAccessor, log
             task {
                 try
                     // Check for agent identity via X-Agent-Id header first
+                    // Only use agent identity if no existing authentication is present
                     match tryCreateAgentPrincipal() with
-                    | Some agentPrincipal -> return agentPrincipal
-                    | None ->
+                    | Some agentPrincipal when not (principal.Identity <> null && principal.Identity.IsAuthenticated) ->
+                        return agentPrincipal
+                    | _ ->
 
                     // Log entry point with any existing user ID
                     if not (isNull log) then

--- a/src/TicTacToe.Web/Program.fs
+++ b/src/TicTacToe.Web/Program.fs
@@ -1,5 +1,6 @@
 open System
 open System.IO.Compression
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Authentication
 open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Builder
@@ -138,7 +139,7 @@ let main args =
 
         plugBeforeRoutingWhenNot isDevelopment (fun app -> ExceptionHandlerExtensions.UseExceptionHandler(app, "/error", true))
 
-        useAuthentication (fun auth -> auth.AddCookie(fun options -> options.Cookie.Name <- "TicTacToe.User"; options.Cookie.HttpOnly <- true; options.Cookie.SameSite <- SameSiteMode.Strict; options.Cookie.SecurePolicy <- CookieSecurePolicy.SameAsRequest; options.ExpireTimeSpan <- TimeSpan.FromDays(30.0); options.SlidingExpiration <- true; options.LoginPath <- "/login"))
+        useAuthentication (fun auth -> auth.AddCookie(fun options -> options.Cookie.Name <- "TicTacToe.User"; options.Cookie.HttpOnly <- true; options.Cookie.SameSite <- SameSiteMode.Strict; options.Cookie.SecurePolicy <- CookieSecurePolicy.SameAsRequest; options.ExpireTimeSpan <- TimeSpan.FromDays(30.0); options.SlidingExpiration <- true; options.LoginPath <- "/login"; options.Events <- CookieAuthenticationEvents(OnRedirectToLogin = fun ctx -> if ctx.Request.Headers.ContainsKey("X-Agent-Id") then ctx.Response.StatusCode <- 401; Task.CompletedTask else ctx.Response.Redirect(ctx.RedirectUri); Task.CompletedTask)))
 
         useAuthorization
 

--- a/src/TicTacToe.Web/Program.fs
+++ b/src/TicTacToe.Web/Program.fs
@@ -139,7 +139,7 @@ let main args =
 
         plugBeforeRoutingWhenNot isDevelopment (fun app -> ExceptionHandlerExtensions.UseExceptionHandler(app, "/error", true))
 
-        useAuthentication (fun auth -> auth.AddCookie(fun options -> options.Cookie.Name <- "TicTacToe.User"; options.Cookie.HttpOnly <- true; options.Cookie.SameSite <- SameSiteMode.Strict; options.Cookie.SecurePolicy <- CookieSecurePolicy.SameAsRequest; options.ExpireTimeSpan <- TimeSpan.FromDays(30.0); options.SlidingExpiration <- true; options.LoginPath <- "/login"; options.Events <- CookieAuthenticationEvents(OnRedirectToLogin = fun ctx -> if ctx.Request.Headers.ContainsKey("X-Agent-Id") then ctx.Response.StatusCode <- 401; Task.CompletedTask else ctx.Response.Redirect(ctx.RedirectUri); Task.CompletedTask)))
+        useAuthentication (fun auth -> auth.AddCookie(fun options -> options.Cookie.Name <- "TicTacToe.User"; options.Cookie.HttpOnly <- true; options.Cookie.SameSite <- SameSiteMode.Strict; options.Cookie.SecurePolicy <- CookieSecurePolicy.SameAsRequest; options.ExpireTimeSpan <- TimeSpan.FromDays(30.0); options.SlidingExpiration <- true; options.LoginPath <- "/login"; options.Events <- CookieAuthenticationEvents(OnRedirectToLogin = fun ctx -> if ctx.Request.Headers.ContainsKey("X-Agent-Id") then ctx.Response.StatusCode <- 401; ctx.Response.Headers["WWW-Authenticate"] <- "X-Agent-Id realm=\"TicTacToe\""; Task.CompletedTask else ctx.Response.Redirect(ctx.RedirectUri); Task.CompletedTask)))
 
         useAuthorization
 

--- a/src/TicTacToe.Web/TicTacToe.Web.fsproj
+++ b/src/TicTacToe.Web/TicTacToe.Web.fsproj
@@ -24,12 +24,12 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="10.1.201" />
-    <PackageReference Include="Frank" Version="7.3.0" />
-    <PackageReference Include="Frank.Auth" Version="7.3.0" />
-    <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.0" />
-    <PackageReference Include="Frank.Datastar" Version="7.3.0" />
-    <PackageReference Include="Frank.Discovery" Version="7.3.0" />
-    <PackageReference Include="Frank.Statecharts" Version="7.3.0" />
+    <PackageReference Include="Frank" Version="7.3.1" />
+    <PackageReference Include="Frank.Auth" Version="7.3.1" />
+    <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.1" />
+    <PackageReference Include="Frank.Datastar" Version="7.3.1" />
+    <PackageReference Include="Frank.Discovery" Version="7.3.1" />
+    <PackageReference Include="Frank.Statecharts" Version="7.3.1" />
     <PackageReference Include="Oxpecker.ViewEngine" Version="2.*" />
   </ItemGroup>
 

--- a/src/TicTacToe.Web/TicTacToe.Web.fsproj
+++ b/src/TicTacToe.Web/TicTacToe.Web.fsproj
@@ -23,10 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
-    <PackageReference Include="Frank" Version="7.1.0" />
-    <PackageReference Include="Frank.Datastar" Version="7.1.0" />
-    <PackageReference Include="Frank.Auth" Version="7.1.0" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
+    <PackageReference Include="Frank" Version="7.3.0" />
+    <PackageReference Include="Frank.Auth" Version="7.3.0" />
+    <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.0" />
+    <PackageReference Include="Frank.Datastar" Version="7.3.0" />
+    <PackageReference Include="Frank.Statecharts.Core" Version="7.3.0" />
     <PackageReference Include="Oxpecker.ViewEngine" Version="2.*" />
   </ItemGroup>
 

--- a/src/TicTacToe.Web/TicTacToe.Web.fsproj
+++ b/src/TicTacToe.Web/TicTacToe.Web.fsproj
@@ -28,7 +28,8 @@
     <PackageReference Include="Frank.Auth" Version="7.3.0" />
     <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.0" />
     <PackageReference Include="Frank.Datastar" Version="7.3.0" />
-    <PackageReference Include="Frank.Statecharts.Core" Version="7.3.0" />
+    <PackageReference Include="Frank.Discovery" Version="7.3.0" />
+    <PackageReference Include="Frank.Statecharts" Version="7.3.0" />
     <PackageReference Include="Oxpecker.ViewEngine" Version="2.*" />
   </ItemGroup>
 

--- a/test/TicTacToe.Engine.Tests/TicTacToe.Engine.Tests.fsproj
+++ b/test/TicTacToe.Engine.Tests/TicTacToe.Engine.Tests.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
     <PackageReference Include="FSharp.Control.Reactive.Testing" Version="6.1.2" />
     <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.15.*" />

--- a/test/TicTacToe.Web.Tests/TicTacToe.Web.Tests.fsproj
+++ b/test/TicTacToe.Web.Tests/TicTacToe.Web.Tests.fsproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
     <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.15.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />


### PR DESCRIPTION
## Summary
- Extend `GameUserClaimsTransformation` to check `X-Agent-Id` header before cookie flow
- Agent identity uses auth type `TicTacToe.Agent` (distinguishable from `TicTacToe.User`)
- Agents get 401 instead of 302 redirect via `OnRedirectToLogin` event

Closes #20

## Verification
- [x] `dotnet build` — 0 errors
- [x] 67 engine tests pass
- [x] Cookie auth unchanged for human players

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>