### PR TITLE
feat: adopt Frank.Statecharts for state-dependent routing and affordances

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,31 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(dotnet *)",
+      "Bash(TEST_BASE_URL=* dotnet *)",
+      "Bash(HEADED=* TEST_BASE_URL=* dotnet *)",
+      "Bash(TEST_BASE_URL=* timeout * dotnet *)",
+      "Bash(timeout * dotnet *)",
+      "Bash(git *)",
+      "Bash(gh *)",
+      "Bash(curl *)",
+      "Bash(timeout * curl *)",
+      "Bash(pkill *)",
+      "Bash(pgrep *)",
+      "Bash(kill *)",
+      "Bash(lsof *)",
+      "Bash(smcat *)",
+      "Bash(xmllint *)",
+      "Bash(.specify/scripts/bash/*)",
+      "WebFetch(domain:data-star.dev)",
+      "WebFetch(domain:www.nuget.org)",
+      "WebFetch(domain:github.com)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebFetch(domain:playwright.dev)",
+      "WebFetch(domain:lanayx.github.io)",
+      "WebSearch",
+      "mcp__plugin_context7_context7__resolve-library-id",
+      "mcp__plugin_context7_context7__query-docs"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Thumbs.db
 .idea/
 packages/
 BenchmarkDotNet.Artifacts/
+
+# AI
+.claude/settings.local.json

--- a/docs/auth.scxml
+++ b/docs/auth.scxml
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" initial="AwaitingLogin">
+<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" name="TicTacToeAuth" initial="AwaitingLogin">
 
   <!--
     Authentication Child State Machine
     Models cookie-based authentication.
     Invoked from the main statechart (statechart.scxml).
+
+    Validated for Frank.Cli 7.3.0 (frank statechart parse/validate).
   -->
 
   <state id="AwaitingLogin">

--- a/docs/game.scxml
+++ b/docs/game.scxml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" initial="Playing">
+<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" name="TicTacToeGame" initial="Playing">
 
   <!--
     Game Child State Machine (single game instance)
     Models a single tic-tac-toe game from creation to disposal.
+    This is a TEMPLATE: the GameSupervisor creates runtime instances.
     Multiple instances may run concurrently, one per game board.
     Invoked from the main statechart (statechart.scxml).
 
@@ -11,7 +12,22 @@
       - GamePlay: turn-by-turn game progression
       - PlayerIdentity: player role assignment
 
+    State alignment with MoveResult DU:
+      XTurn     -> MoveResult.XTurn
+      OTurn     -> MoveResult.OTurn
+      Won       -> MoveResult.Won
+      Draw      -> MoveResult.Draw
+      MoveError -> MoveResult.Error (transient, returns via history)
+      Disposed  -> removed from GameSupervisor store
+
     Lifecycle events (dispose, reset, timeout) exit the entire game.
+
+    Note: ECMAScript guard functions (wouldWin, wouldFillBoard,
+    isParticipant, hasActivity) and <assign> actions are out of scope
+    for the Frank.Cli statechart parser (silently skipped). The guards
+    are preserved as string expressions in the AST for documentation.
+
+    Validated for Frank.Cli 7.3.0 (frank statechart parse/validate).
   -->
 
   <datamodel>

--- a/docs/statechart.scxml
+++ b/docs/statechart.scxml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" initial="Unauthenticated">
+<scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" datamodel="ecmascript" name="TicTacToeApp" initial="Unauthenticated">
 
   <!--
     TicTacToe Application Statechart
@@ -10,7 +10,12 @@
       3. Participate in games (child state machine: game.scxml)
 
     Auth and Game are invoked as child state machines.
-    Multiple game instances may be active concurrently.
+    The game.scxml child machine is a TEMPLATE for a single game instance;
+    the GameSupervisor creates runtime instances from this template.
+    Multiple game instances may be active concurrently, but concurrent
+    participation is managed at runtime, not modeled in SCXML.
+
+    Validated for Frank.Cli 7.3.0 (frank statechart parse/validate).
   -->
 
   <state id="Unauthenticated">

--- a/src/TicTacToe.Engine/TicTacToe.Engine.fsproj
+++ b/src/TicTacToe.Engine/TicTacToe.Engine.fsproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
   </ItemGroup>
 
 </Project>

--- a/src/TicTacToe.Web/Handlers.fs
+++ b/src/TicTacToe.Web/Handlers.fs
@@ -10,6 +10,7 @@ open Microsoft.AspNetCore.Http
 open Microsoft.Extensions.DependencyInjection
 open Oxpecker.ViewEngine
 open Frank.Datastar
+open Frank.Statecharts
 open TicTacToe.Web.SseBroadcast
 open TicTacToe.Web.templates.shared
 open TicTacToe.Web.templates.game
@@ -28,10 +29,14 @@ type MoveSignals =
 let private gameSubscriptions =
     System.Collections.Concurrent.ConcurrentDictionary<string, IDisposable>()
 
-/// Subscribe to a game's state changes and broadcast updates
-let subscribeToGame (gameId: string) (game: Game) (assignmentManager: PlayerAssignmentManager) (supervisor: GameSupervisor) =
+/// Subscribe to a game's state changes and broadcast updates.
+/// Sets up two independent observers:
+///   1. SSE broadcast observer (existing) — drives broadcastPerRole for Datastar
+///   2. Statechart store observer (new) — updates GamePhase in the store
+let subscribeToGame (gameId: string) (game: Game) (assignmentManager: PlayerAssignmentManager) (supervisor: GameSupervisor) (store: IStateMachineStore<GamePhase, unit>) =
     if not (gameSubscriptions.ContainsKey(gameId)) then
-        let subscription =
+        // Observer 1: SSE broadcast (existing behavior)
+        let sseSub =
             game.Subscribe(
                 { new IObserver<MoveResult> with
                     member _.OnNext(result) =
@@ -52,7 +57,26 @@ let subscribeToGame (gameId: string) (game: Game) (assignmentManager: PlayerAssi
                         | _ -> () }
             )
 
-        gameSubscriptions.TryAdd(gameId, subscription) |> ignore
+        // Observer 2: Statechart store update — keeps GamePhase in sync with Engine
+        let storeSub =
+            game.Subscribe(
+                { new IObserver<MoveResult> with
+                    member _.OnNext(result) =
+                        let phase = toGamePhase result
+                        store.SetState gameId phase () |> ignore
+
+                    member _.OnError(_) = ()
+                    member _.OnCompleted() = () }
+            )
+
+        // Combine both subscriptions into a single disposable
+        let combined =
+            { new IDisposable with
+                member _.Dispose() =
+                    sseSub.Dispose()
+                    storeSub.Dispose() }
+
+        gameSubscriptions.TryAdd(gameId, combined) |> ignore
 
 /// Login endpoint - signs in user and redirects back
 /// This creates a persistent cookie for user identification
@@ -175,10 +199,14 @@ let createGame (ctx: HttpContext) =
     task {
         let supervisor = ctx.RequestServices.GetRequiredService<GameSupervisor>()
         let assignmentManager = ctx.RequestServices.GetRequiredService<PlayerAssignmentManager>()
+        let store = ctx.RequestServices.GetRequiredService<IStateMachineStore<GamePhase, unit>>()
         let (gameId, game) = supervisor.CreateGame()
 
+        // Seed initial state in the statechart store
+        do! store.SetState gameId GamePhase.XTurn ()
+
         // Subscribe to game state changes
-        subscribeToGame gameId game assignmentManager supervisor
+        subscribeToGame gameId game assignmentManager supervisor store
 
         // Get initial state and broadcast to all clients
         use initialSub =
@@ -203,12 +231,13 @@ let getGame (ctx: HttpContext) =
     task {
         let supervisor = ctx.RequestServices.GetRequiredService<GameSupervisor>()
         let assignmentManager = ctx.RequestServices.GetRequiredService<PlayerAssignmentManager>()
+        let store = ctx.RequestServices.GetRequiredService<IStateMachineStore<GamePhase, unit>>()
         let gameId = ctx.Request.RouteValues.["id"] |> string
 
         match supervisor.GetGame(gameId) with
         | Some game ->
             // Subscribe to ensure updates are broadcast
-            subscribeToGame gameId game assignmentManager supervisor
+            subscribeToGame gameId game assignmentManager supervisor store
 
             // Get current state via a temporary subscription
             let mutable currentResult: MoveResult option = None
@@ -239,7 +268,9 @@ let private isXTurn (moveResult: MoveResult) =
     | MoveResult.XTurn _ -> true
     | _ -> false
 
-/// POST /games/{id} - Make a move in a specific game
+/// POST /games/{id} - Make a move in a specific game.
+/// The statechart middleware has already checked guards (turn order via claims).
+/// This handler performs assignment validation and delegates to the Engine.
 let makeMove (ctx: HttpContext) =
     task {
         let supervisor = ctx.RequestServices.GetRequiredService<GameSupervisor>()
@@ -247,6 +278,7 @@ let makeMove (ctx: HttpContext) =
         let assignmentManager =
             ctx.RequestServices.GetRequiredService<PlayerAssignmentManager>()
 
+        let store = ctx.RequestServices.GetRequiredService<IStateMachineStore<GamePhase, unit>>()
         let gameId = ctx.Request.RouteValues.["id"] |> string
 
         // Get user ID from authenticated user
@@ -272,8 +304,15 @@ let makeMove (ctx: HttpContext) =
                     match validationResult with
                     | Allowed ->
                         // Ensure we're subscribed to broadcast updates
-                        subscribeToGame gameId game assignmentManager supervisor
+                        subscribeToGame gameId game assignmentManager supervisor store
                         game.MakeMove(moveAction)
+
+                        // Set event for statechart middleware transition
+                        let position =
+                            match moveAction with
+                            | XMove pos | OMove pos -> pos
+                        StateMachineContext.setEvent ctx (GameEvent.MakeMove position)
+
                         ctx.Response.StatusCode <- 202
                     | Rejected reason ->
                         // Move was rejected - broadcast rejection animation
@@ -293,7 +332,8 @@ let makeMove (ctx: HttpContext) =
             ctx.Response.StatusCode <- 401
     }
 
-/// DELETE /games/{id} - Delete a game
+/// DELETE /games/{id} - Delete a game.
+/// The statechart middleware checks method is allowed in current state.
 let deleteGame (ctx: HttpContext) =
     task {
         let supervisor = ctx.RequestServices.GetRequiredService<GameSupervisor>()
@@ -335,6 +375,7 @@ let resetGame (ctx: HttpContext) =
     task {
         let supervisor = ctx.RequestServices.GetRequiredService<GameSupervisor>()
         let assignmentManager = ctx.RequestServices.GetRequiredService<PlayerAssignmentManager>()
+        let store = ctx.RequestServices.GetRequiredService<IStateMachineStore<GamePhase, unit>>()
         let gameId = ctx.Request.RouteValues.["id"] |> string
 
         // Get user ID from authenticated user
@@ -356,8 +397,11 @@ let resetGame (ctx: HttpContext) =
                     // Create new game first (maintains count)
                     let (newGameId, newGame) = supervisor.CreateGame()
 
+                    // Seed initial state in the statechart store for the new game
+                    do! store.SetState newGameId GamePhase.XTurn ()
+
                     // Subscribe to new game state changes
-                    subscribeToGame newGameId newGame assignmentManager supervisor
+                    subscribeToGame newGameId newGame assignmentManager supervisor store
 
                     // Clear old game's player assignments
                     assignmentManager.RemoveGame(gameId)

--- a/src/TicTacToe.Web/Handlers.fs
+++ b/src/TicTacToe.Web/Handlers.fs
@@ -63,7 +63,11 @@ let subscribeToGame (gameId: string) (game: Game) (assignmentManager: PlayerAssi
                 { new IObserver<MoveResult> with
                     member _.OnNext(result) =
                         let phase = toGamePhase result
-                        store.SetState gameId phase () |> ignore
+                        // Synchronous blocking is acceptable here: IObserver.OnNext is
+                        // synchronous, and the in-memory MailboxProcessorStore has no
+                        // SynchronizationContext deadlock risk under Kestrel.
+                        store.SetState gameId phase ()
+                        |> fun t -> t.GetAwaiter().GetResult()
 
                     member _.OnError(_) = ()
                     member _.OnCompleted() = () }
@@ -359,6 +363,11 @@ let deleteGame (ctx: HttpContext) =
 
                     // Dispose the game - this triggers OnCompleted which removes subscription
                     game.Dispose()
+
+                    // TODO: Remove orphaned store entry for this gameId.
+                    // IStateMachineStore currently has no RemoveState method, so the
+                    // entry persists. Acceptable for in-memory store (cleared on restart)
+                    // but should be revisited if the store becomes durable/distributed.
 
                     // Broadcast removal to all clients
                     broadcast (RemoveElement $"#game-{gameId}")

--- a/src/TicTacToe.Web/Model.fs
+++ b/src/TicTacToe.Web/Model.fs
@@ -2,8 +2,42 @@ module TicTacToe.Web.Model
 
 // Player assignment types for multi-player support
 // This module tracks which authenticated users are assigned to which game roles
+// Also defines GamePhase DU for statechart integration (Web layer only, not Engine)
 
 open System
+open TicTacToe.Model
+
+// ============================================================================
+// GamePhase — statechart state (Web layer only, Engine untouched)
+// ============================================================================
+
+/// Game phase for statechart state machine. Maps from Engine's MoveResult.
+/// RequireQualifiedAccess avoids shadowing MoveResult's XTurn/OTurn/Won/Draw/Error cases.
+[<RequireQualifiedAccess>]
+[<StructuralEquality; StructuralComparison>]
+type GamePhase =
+    | XTurn
+    | OTurn
+    | Won
+    | Draw
+    | Error
+
+/// Events that trigger statechart transitions.
+/// RequireQualifiedAccess to avoid shadowing Engine's MakeMove.
+[<RequireQualifiedAccess>]
+type GameEvent =
+    | MakeMove of position: SquarePosition
+    | Reset
+    | Delete
+
+/// Convert Engine's MoveResult to the statechart GamePhase.
+let toGamePhase (result: MoveResult) : GamePhase =
+    match result with
+    | MoveResult.XTurn _ -> GamePhase.XTurn
+    | MoveResult.OTurn _ -> GamePhase.OTurn
+    | MoveResult.Won _ -> GamePhase.Won
+    | MoveResult.Draw _ -> GamePhase.Draw
+    | MoveResult.Error _ -> GamePhase.Error
 
 /// Reasons why a move was rejected
 type RejectionReason =

--- a/src/TicTacToe.Web/Program.fs
+++ b/src/TicTacToe.Web/Program.fs
@@ -67,40 +67,51 @@ let configureServices (services: IServiceCollection) =
 /// on HttpContext.Features. Also enriches the user's claims with player assignment
 /// for the current game so role predicates and guards can check them.
 /// Must run AFTER routing and BEFORE the statechart middleware.
+///
+/// Enforces authentication for stateful resource endpoints: unauthenticated
+/// requests are challenged (302 redirect to login) before reaching the
+/// statechart middleware or any handler.
 let resolveStateKey (app: IApplicationBuilder) =
     app.Use(
         Func<HttpContext, Func<Task>, Task>(fun ctx next ->
             task {
                 let endpoint = ctx.GetEndpoint()
+                let mutable challenged = false
 
                 if not (isNull endpoint) then
                     let metadata = endpoint.Metadata.GetMetadata<StateMachineMetadata>()
 
                     if not (obj.ReferenceEquals(metadata, null)) then
-                        let instanceId = metadata.ResolveInstanceId ctx
+                        // Enforce authentication — statefulResource endpoints require auth
+                        if not ctx.User.Identity.IsAuthenticated then
+                            do! ctx.ChallengeAsync()
+                            challenged <- true
+                        else
+                            let instanceId = metadata.ResolveInstanceId ctx
 
-                        // Enrich user claims with player assignment for this game
-                        let assignmentManager =
-                            ctx.RequestServices.GetRequiredService<PlayerAssignmentManager>()
-                        let assignment = assignmentManager.GetAssignment(instanceId)
-                        let userId = ctx.User.TryGetUserId()
+                            // Enrich user claims with player assignment for this game
+                            let assignmentManager =
+                                ctx.RequestServices.GetRequiredService<PlayerAssignmentManager>()
+                            let assignment = assignmentManager.GetAssignment(instanceId)
+                            let userId = ctx.User.TryGetUserId()
 
-                        match assignment, userId with
-                        | Some a, Some uid ->
-                            let claims = ResizeArray<Claim>()
-                            if a.PlayerXId = Some uid then
-                                claims.Add(Claim("player", "X"))
-                            elif a.PlayerOId = Some uid then
-                                claims.Add(Claim("player", "O"))
-                            if claims.Count > 0 then
-                                let identity = ClaimsIdentity(claims, "GameAssignment")
-                                ctx.User.AddIdentity(identity)
-                        | _ -> ()
+                            match assignment, userId with
+                            | Some a, Some uid ->
+                                let claims = ResizeArray<Claim>()
+                                if a.PlayerXId = Some uid then
+                                    claims.Add(Claim("player", "X"))
+                                elif a.PlayerOId = Some uid then
+                                    claims.Add(Claim("player", "O"))
+                                if claims.Count > 0 then
+                                    let identity = ClaimsIdentity(claims, "GameAssignment")
+                                    ctx.User.AddIdentity(identity)
+                            | _ -> ()
 
-                        let! _stateKey = metadata.GetCurrentStateKey ctx.RequestServices ctx instanceId
-                        ()
+                            let! _stateKey = metadata.GetCurrentStateKey ctx.RequestServices ctx instanceId
+                            ()
 
-                do! next.Invoke()
+                if not challenged then
+                    do! next.Invoke()
             }
             :> Task)
     )

--- a/src/TicTacToe.Web/Program.fs
+++ b/src/TicTacToe.Web/Program.fs
@@ -1,5 +1,7 @@
 open System
 open System.IO.Compression
+open System.Security.Claims
+open System.Threading.Tasks
 open Microsoft.AspNetCore.Authentication
 open Microsoft.AspNetCore.Authentication.Cookies
 open Microsoft.AspNetCore.Builder
@@ -11,8 +13,11 @@ open Microsoft.Extensions.Logging
 open Frank.Builder
 open Frank.Auth
 open Frank.Datastar
+open Frank.Statecharts
+open Frank.Affordances
 open TicTacToe.Web
 open TicTacToe.Web.Model
+open TicTacToe.Web.GameStateMachine
 open TicTacToe.Engine
 open TicTacToe.Web.Extensions
 
@@ -25,6 +30,9 @@ let configureServices (services: IServiceCollection) =
     services.AddRouting().AddHttpContextAccessor() |> ignore
 
     services.AddAntiforgery() |> ignore
+
+    // Add statechart store for GamePhase tracking
+    services.AddStateMachineStore<GamePhase, unit>() |> ignore
 
     services
         .AddSingleton<GameSupervisor>(fun _ -> createGameSupervisor ())
@@ -51,7 +59,56 @@ let configureServices (services: IServiceCollection) =
 
     services
 
+// ============================================================================
+// State key resolver middleware
+// ============================================================================
+
+/// Resolves the statechart state key from the store and sets IStatechartFeature
+/// on HttpContext.Features. Also enriches the user's claims with player assignment
+/// for the current game so role predicates and guards can check them.
+/// Must run AFTER routing and BEFORE the statechart middleware.
+let resolveStateKey (app: IApplicationBuilder) =
+    app.Use(
+        Func<HttpContext, Func<Task>, Task>(fun ctx next ->
+            task {
+                let endpoint = ctx.GetEndpoint()
+
+                if not (isNull endpoint) then
+                    let metadata = endpoint.Metadata.GetMetadata<StateMachineMetadata>()
+
+                    if not (obj.ReferenceEquals(metadata, null)) then
+                        let instanceId = metadata.ResolveInstanceId ctx
+
+                        // Enrich user claims with player assignment for this game
+                        let assignmentManager =
+                            ctx.RequestServices.GetRequiredService<PlayerAssignmentManager>()
+                        let assignment = assignmentManager.GetAssignment(instanceId)
+                        let userId = ctx.User.TryGetUserId()
+
+                        match assignment, userId with
+                        | Some a, Some uid ->
+                            let claims = ResizeArray<Claim>()
+                            if a.PlayerXId = Some uid then
+                                claims.Add(Claim("player", "X"))
+                            elif a.PlayerOId = Some uid then
+                                claims.Add(Claim("player", "O"))
+                            if claims.Count > 0 then
+                                let identity = ClaimsIdentity(claims, "GameAssignment")
+                                ctx.User.AddIdentity(identity)
+                        | _ -> ()
+
+                        let! _stateKey = metadata.GetCurrentStateKey ctx.RequestServices ctx instanceId
+                        ()
+
+                do! next.Invoke()
+            }
+            :> Task)
+    )
+
+// ============================================================================
 // Resources
+// ============================================================================
+
 let login =
     resource "/login" {
         name "Login"
@@ -90,13 +147,24 @@ let games =
         post Handlers.createGame
     }
 
+/// Adapter: upcast Task<unit> -> Task for StateHandlerBuilder compatibility.
+let inline asTask (handler: HttpContext -> Task<unit>) : HttpContext -> Task =
+    fun ctx -> handler ctx :> Task
+
+/// Stateful game resource — the statechart middleware handles state-dependent
+/// routing, method checks, and guard evaluation (turn order via claims).
 let gameById =
-    resource "/games/{id}" {
-        name "GameById"
-        requireAuth
-        get Handlers.getGame
-        post Handlers.makeMove
-        delete Handlers.deleteGame
+    statefulResource "/games/{id}" {
+        machine gameMachine
+        resolveInstanceId (fun ctx -> ctx.Request.RouteValues.["id"] |> string)
+        role "PlayerX" (fun user -> user.HasClaim("player", "X"))
+        role "PlayerO" (fun user -> user.HasClaim("player", "O"))
+        role "Spectator" (fun _user -> true)
+        inState (forState GamePhase.XTurn [ StateHandlerBuilder.get (asTask Handlers.getGame); StateHandlerBuilder.post (asTask Handlers.makeMove); StateHandlerBuilder.delete (asTask Handlers.deleteGame) ])
+        inState (forState GamePhase.OTurn [ StateHandlerBuilder.get (asTask Handlers.getGame); StateHandlerBuilder.post (asTask Handlers.makeMove); StateHandlerBuilder.delete (asTask Handlers.deleteGame) ])
+        inState (forState GamePhase.Won [ StateHandlerBuilder.get (asTask Handlers.getGame); StateHandlerBuilder.delete (asTask Handlers.deleteGame) ])
+        inState (forState GamePhase.Draw [ StateHandlerBuilder.get (asTask Handlers.getGame); StateHandlerBuilder.delete (asTask Handlers.deleteGame) ])
+        inState (forState GamePhase.Error [ StateHandlerBuilder.get (asTask Handlers.getGame) ])
     }
 
 let gameReset =
@@ -116,11 +184,16 @@ let createInitialGames (app: IApplicationBuilder) =
     let assignmentManager =
         app.ApplicationServices.GetRequiredService<PlayerAssignmentManager>()
 
+    let store =
+        app.ApplicationServices.GetRequiredService<IStateMachineStore<GamePhase, unit>>()
+
     lifetime.ApplicationStarted.Register(fun () ->
         // Create 6 initial games
         for _ in 1..6 do
             let (gameId, game) = supervisor.CreateGame()
-            Handlers.subscribeToGame gameId game assignmentManager supervisor)
+            // Seed initial state in the statechart store
+            store.SetState gameId GamePhase.XTurn () |> fun t -> t.Wait()
+            Handlers.subscribeToGame gameId game assignmentManager supervisor store)
     |> ignore
 
     app
@@ -146,6 +219,16 @@ let main args =
         plugBeforeRouting StaticFileExtensions.UseStaticFiles
         plugBeforeRouting AntiforgeryApplicationBuilderExtensions.UseAntiforgery
         plugBeforeRouting createInitialGames
+
+        // Statechart middleware pipeline (after routing, before endpoint execution):
+        // 1. State key resolver (reads store, enriches claims, sets IStatechartFeature)
+        plug resolveStateKey
+        // 2. Affordance middleware (reads IStatechartFeature, injects Link + Allow headers)
+        useAffordances
+        // 3. Projected profile middleware (role-specific ALPS profile links)
+        useProjectedProfiles
+        // 4. Statechart middleware (state-dependent handler dispatch)
+        useStatecharts
 
         resource login
         resource logout

--- a/src/TicTacToe.Web/Program.fs
+++ b/src/TicTacToe.Web/Program.fs
@@ -83,7 +83,7 @@ let resolveStateKey (app: IApplicationBuilder) =
 
                     if not (obj.ReferenceEquals(metadata, null)) then
                         // Enforce authentication — statefulResource endpoints require auth
-                        if not ctx.User.Identity.IsAuthenticated then
+                        if ctx.User.Identity |> isNull || not ctx.User.Identity.IsAuthenticated then
                             do! ctx.ChallengeAsync()
                             challenged <- true
                         else
@@ -203,7 +203,10 @@ let createInitialGames (app: IApplicationBuilder) =
         for _ in 1..6 do
             let (gameId, game) = supervisor.CreateGame()
             // Seed initial state in the statechart store
-            store.SetState gameId GamePhase.XTurn () |> fun t -> t.Wait()
+            // GetAwaiter().GetResult() avoids AggregateException wrapping (unlike .Wait()).
+            // Synchronous blocking is acceptable: ApplicationStarted callback is Action (sync),
+            // and the in-memory store has no SynchronizationContext deadlock risk.
+            store.SetState gameId GamePhase.XTurn () |> fun t -> t.GetAwaiter().GetResult()
             Handlers.subscribeToGame gameId game assignmentManager supervisor store)
     |> ignore
 

--- a/src/TicTacToe.Web/StateMachine.fs
+++ b/src/TicTacToe.Web/StateMachine.fs
@@ -34,26 +34,32 @@ let gameTransition (state: GamePhase) (event: GameEvent) (_ctx: unit) =
 /// Turn guard: checks that the user has the correct player claim for the current turn.
 /// The role predicates resolve "PlayerX"/"PlayerO" from claims; this guard
 /// checks that the resolved role matches the current phase.
+///
+/// Uses EventValidation (post-handler) so it only fires when a MakeMove event is set.
+/// GET and DELETE requests don't set events, so they pass through without turn checks.
 let turnGuard: Guard<GamePhase, GameEvent, unit> =
-    AccessControl(
+    EventValidation(
         "TurnGuard",
         fun ctx ->
-            match ctx.CurrentState with
-            | GamePhase.XTurn ->
-                if ctx.HasRole("PlayerX") then GuardResult.Allowed
-                elif ctx.HasRole("PlayerO") then GuardResult.Blocked BlockReason.NotYourTurn
-                else
-                    // Unassigned user — allow (assignment happens in handler)
+            match ctx.Event with
+            | GameEvent.MakeMove _ ->
+                match ctx.CurrentState with
+                | GamePhase.XTurn ->
+                    if ctx.HasRole("PlayerX") then GuardResult.Allowed
+                    elif ctx.HasRole("PlayerO") then GuardResult.Blocked BlockReason.NotYourTurn
+                    else
+                        // Unassigned user — allow (assignment happens in handler)
+                        GuardResult.Allowed
+                | GamePhase.OTurn ->
+                    if ctx.HasRole("PlayerO") then GuardResult.Allowed
+                    elif ctx.HasRole("PlayerX") then GuardResult.Blocked BlockReason.NotYourTurn
+                    else
+                        // Unassigned user — allow (assignment happens in handler)
+                        GuardResult.Allowed
+                | GamePhase.Won | GamePhase.Draw | GamePhase.Error ->
+                    // Terminal states — moves are blocked by the transition function
                     GuardResult.Allowed
-            | GamePhase.OTurn ->
-                if ctx.HasRole("PlayerO") then GuardResult.Allowed
-                elif ctx.HasRole("PlayerX") then GuardResult.Blocked BlockReason.NotYourTurn
-                else
-                    // Unassigned user — allow (assignment happens in handler)
-                    GuardResult.Allowed
-            | GamePhase.Won | GamePhase.Draw | GamePhase.Error ->
-                // GET is allowed in terminal states; POST will be blocked by method check
-                GuardResult.Allowed
+            | _ -> GuardResult.Allowed
     )
 
 // ============================================================================

--- a/src/TicTacToe.Web/StateMachine.fs
+++ b/src/TicTacToe.Web/StateMachine.fs
@@ -1,0 +1,89 @@
+module TicTacToe.Web.GameStateMachine
+
+open Frank.Statecharts
+open Frank.Resources.Model
+open TicTacToe.Web.Model
+
+// ============================================================================
+// Transition function
+// ============================================================================
+
+/// Statechart context: unit (all real game state lives in Engine's GameSupervisor).
+/// The statechart only tracks phase transitions for routing/affordances.
+let gameTransition (state: GamePhase) (event: GameEvent) (_ctx: unit) =
+    match state, event with
+    // A move from XTurn can go to OTurn, Won, Draw, or Error
+    // The actual outcome is determined by the Engine; the statechart store
+    // is updated by the observer AFTER the Engine processes the move.
+    // For the statechart middleware transition, we just allow the transition.
+    | GamePhase.XTurn, GameEvent.MakeMove _ -> TransitionResult.Transitioned(GamePhase.OTurn, ())
+    | GamePhase.OTurn, GameEvent.MakeMove _ -> TransitionResult.Transitioned(GamePhase.XTurn, ())
+    // Reset creates a new game — the old game's statechart is not reused
+    | _, GameEvent.Reset -> TransitionResult.Transitioned(GamePhase.XTurn, ())
+    // Delete is a terminal action
+    | _, GameEvent.Delete -> TransitionResult.Invalid "Delete removes the game"
+    // Cannot move in terminal states
+    | GamePhase.Won, GameEvent.MakeMove _ -> TransitionResult.Invalid "Game already over"
+    | GamePhase.Draw, GameEvent.MakeMove _ -> TransitionResult.Invalid "Game already over"
+    | GamePhase.Error, GameEvent.MakeMove _ -> TransitionResult.Invalid "Game in error state"
+
+// ============================================================================
+// Guards
+// ============================================================================
+
+/// Turn guard: checks that the user has the correct player claim for the current turn.
+/// The role predicates resolve "PlayerX"/"PlayerO" from claims; this guard
+/// checks that the resolved role matches the current phase.
+let turnGuard: Guard<GamePhase, GameEvent, unit> =
+    AccessControl(
+        "TurnGuard",
+        fun ctx ->
+            match ctx.CurrentState with
+            | GamePhase.XTurn ->
+                if ctx.HasRole("PlayerX") then GuardResult.Allowed
+                elif ctx.HasRole("PlayerO") then GuardResult.Blocked BlockReason.NotYourTurn
+                else
+                    // Unassigned user — allow (assignment happens in handler)
+                    GuardResult.Allowed
+            | GamePhase.OTurn ->
+                if ctx.HasRole("PlayerO") then GuardResult.Allowed
+                elif ctx.HasRole("PlayerX") then GuardResult.Blocked BlockReason.NotYourTurn
+                else
+                    // Unassigned user — allow (assignment happens in handler)
+                    GuardResult.Allowed
+            | GamePhase.Won | GamePhase.Draw | GamePhase.Error ->
+                // GET is allowed in terminal states; POST will be blocked by method check
+                GuardResult.Allowed
+    )
+
+// ============================================================================
+// State machine definition
+// ============================================================================
+
+let gameMachine: StateMachine<GamePhase, GameEvent, unit> =
+    { Initial = GamePhase.XTurn
+      InitialContext = ()
+      Transition = gameTransition
+      Guards = [ turnGuard ]
+      StateMetadata =
+        Map.ofList
+            [ GamePhase.XTurn,
+              { AllowedMethods = [ "GET"; "POST"; "DELETE" ]
+                IsFinal = false
+                Description = Some "X's turn to play" }
+              GamePhase.OTurn,
+              { AllowedMethods = [ "GET"; "POST"; "DELETE" ]
+                IsFinal = false
+                Description = Some "O's turn to play" }
+              GamePhase.Won,
+              { AllowedMethods = [ "GET"; "DELETE" ]
+                IsFinal = true
+                Description = Some "Game over: someone won" }
+              GamePhase.Draw,
+              { AllowedMethods = [ "GET"; "DELETE" ]
+                IsFinal = true
+                Description = Some "Game over: draw" }
+              GamePhase.Error,
+              { AllowedMethods = [ "GET" ]
+                IsFinal = true
+                Description = Some "Game in error state" } ] }

--- a/src/TicTacToe.Web/StateMachine.fs
+++ b/src/TicTacToe.Web/StateMachine.fs
@@ -16,6 +16,25 @@ let gameTransition (state: GamePhase) (event: GameEvent) (_ctx: unit) =
     // The actual outcome is determined by the Engine; the statechart store
     // is updated by the observer AFTER the Engine processes the move.
     // For the statechart middleware transition, we just allow the transition.
+    // -----------------------------------------------------------------------
+    // KNOWN LIMITATION: Approximate transitions
+    //
+    // These transitions assume a normal alternating-turn outcome. The Engine
+    // owns the real game logic; a move may actually result in Won, Draw, or
+    // Error. The observer in Handlers.fs corrects the store immediately after
+    // the Engine processes the move, so the race window is:
+    //
+    //   middleware transition (approximate) -> handler -> Engine -> observer (corrects)
+    //
+    // This is acceptable because:
+    //   1. The 202 response carries no state representation, so the client
+    //      never sees the intermediate approximate state.
+    //   2. The in-memory MailboxProcessorStore observer fires synchronously
+    //      within the same request pipeline, making the correction near-instant.
+    //
+    // Revisit if the store becomes async/distributed, where the correction
+    // latency could surface stale state to concurrent readers.
+    // -----------------------------------------------------------------------
     | GamePhase.XTurn, GameEvent.MakeMove _ -> TransitionResult.Transitioned(GamePhase.OTurn, ())
     | GamePhase.OTurn, GameEvent.MakeMove _ -> TransitionResult.Transitioned(GamePhase.XTurn, ())
     // Reset creates a new game — the old game's statechart is not reused

--- a/src/TicTacToe.Web/TicTacToe.Web.fsproj
+++ b/src/TicTacToe.Web/TicTacToe.Web.fsproj
@@ -24,12 +24,12 @@
 
   <ItemGroup>
     <PackageReference Update="FSharp.Core" Version="10.1.201" />
-    <PackageReference Include="Frank" Version="7.3.0" />
-    <PackageReference Include="Frank.Auth" Version="7.3.0" />
-    <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.0" />
-    <PackageReference Include="Frank.Datastar" Version="7.3.0" />
-    <PackageReference Include="Frank.Discovery" Version="7.3.0" />
-    <PackageReference Include="Frank.Statecharts" Version="7.3.0" />
+    <PackageReference Include="Frank" Version="7.3.1" />
+    <PackageReference Include="Frank.Auth" Version="7.3.1" />
+    <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.1" />
+    <PackageReference Include="Frank.Datastar" Version="7.3.1" />
+    <PackageReference Include="Frank.Discovery" Version="7.3.1" />
+    <PackageReference Include="Frank.Statecharts" Version="7.3.1" />
     <PackageReference Include="Oxpecker.ViewEngine" Version="2.*" />
   </ItemGroup>
 

--- a/src/TicTacToe.Web/TicTacToe.Web.fsproj
+++ b/src/TicTacToe.Web/TicTacToe.Web.fsproj
@@ -23,10 +23,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
-    <PackageReference Include="Frank" Version="7.1.0" />
-    <PackageReference Include="Frank.Datastar" Version="7.1.0" />
-    <PackageReference Include="Frank.Auth" Version="7.1.0" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
+    <PackageReference Include="Frank" Version="7.3.0" />
+    <PackageReference Include="Frank.Auth" Version="7.3.0" />
+    <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.0" />
+    <PackageReference Include="Frank.Datastar" Version="7.3.0" />
+    <PackageReference Include="Frank.Statecharts.Core" Version="7.3.0" />
     <PackageReference Include="Oxpecker.ViewEngine" Version="2.*" />
   </ItemGroup>
 

--- a/src/TicTacToe.Web/TicTacToe.Web.fsproj
+++ b/src/TicTacToe.Web/TicTacToe.Web.fsproj
@@ -28,7 +28,8 @@
     <PackageReference Include="Frank.Auth" Version="7.3.0" />
     <PackageReference Include="Frank.Cli.MSBuild" Version="7.3.0" />
     <PackageReference Include="Frank.Datastar" Version="7.3.0" />
-    <PackageReference Include="Frank.Statecharts.Core" Version="7.3.0" />
+    <PackageReference Include="Frank.Discovery" Version="7.3.0" />
+    <PackageReference Include="Frank.Statecharts" Version="7.3.0" />
     <PackageReference Include="Oxpecker.ViewEngine" Version="2.*" />
   </ItemGroup>
 

--- a/src/TicTacToe.Web/TicTacToe.Web.fsproj
+++ b/src/TicTacToe.Web/TicTacToe.Web.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="Model.fs" />
+    <Compile Include="StateMachine.fs" />
     <Compile Include="Extensions.fs" />
     <Compile Include="Auth.fs" />
     <Compile Include="SseBroadcast.fs" />

--- a/test/TicTacToe.Engine.Tests/TicTacToe.Engine.Tests.fsproj
+++ b/test/TicTacToe.Engine.Tests/TicTacToe.Engine.Tests.fsproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
     <PackageReference Include="FSharp.Control.Reactive.Testing" Version="6.1.2" />
     <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.15.*" />

--- a/test/TicTacToe.Web.Tests/TicTacToe.Web.Tests.fsproj
+++ b/test/TicTacToe.Web.Tests/TicTacToe.Web.Tests.fsproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FSharp.Core" Version="10.0.102" />
+    <PackageReference Update="FSharp.Core" Version="10.1.201" />
     <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.15.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />


### PR DESCRIPTION
## Summary
- Replace `resource "/games/{id}"` with `statefulResource` CE
- New `GamePhase` DU (XTurn/OTurn/Won/Draw/Error) and `GameEvent` DU in Web/Model.fs
- New `StateMachine.fs` with transition function, turn guard, and state metadata
- Dual observer pattern: SSE broadcast + statechart store sync
- Claims enrichment in state resolver middleware for role predicates
- Full middleware pipeline: resolveStateKey → useAffordances → useProjectedProfiles → useStatecharts
- Auth enforcement for statefulResource endpoints via state resolver middleware
- TurnGuard as EventValidation (post-handler) to avoid blocking GET/DELETE

Engine completely untouched. SSE/broadcastPerRole preserved.

Closes #16

## Verification
- [x] `dotnet build` — 0 errors
- [x] 67/67 engine tests pass
- [x] **94/94 integration tests pass** (full Playwright suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>