### PR TITLE
fix(ci): always install Playwright browsers (decouple from stale cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,14 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
+      # Install runs unconditionally. The cache key above is derived from a wildcard
+      # package version ("1.*"), so it never invalidates across Playwright bumps;
+      # gating install on a cache-hit therefore restored a stale browser set and
+      # skipped fetching the new headless-shell build, failing every launch with
+      # "Executable doesn't exist at .../chromium_headless_shell-NNNN". `playwright
+      # install chromium` is a fast no-op when browsers are present and downloads
+      # only what's missing, so correctness no longer depends on cache freshness.
       - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pwsh test/TicTacToe.Web.Tests/bin/Debug/net10.0/playwright.ps1 install chromium
 
       - name: Install Playwright system dependencies


### PR DESCRIPTION
## Problem
`main` CI has been red since before SP2 (same failure on `677e6fe` and `e201e0f`): the `Run Playwright tests` step fails at fixture setup —

```
Microsoft.Playwright.PlaywrightException : Executable doesn't exist at
/home/runner/.cache/ms-playwright/chromium_headless_shell-1228/.../chrome-headless-shell
```

## Root cause
The browser cache key is `${{ runner.os }}-playwright-${VERSION}`, where `${VERSION}` is grepped from `Microsoft.Playwright.NUnit Version="1.*"` — i.e. the literal wildcard **`1.*`**, a constant. The key never invalidates across Playwright bumps, so a stale browser cache is a permanent cache-hit. The `Install Playwright browsers` step was gated `if: cache-hit != 'true'`, so it was **skipped**, and the newer `chrome-headless-shell` build was never fetched → every headless launch fails.

CI never builds or tests `experiments/`, so this is unrelated to SP2.

## Fix
Run `playwright install chromium` unconditionally. It's a fast no-op when browsers are already present and downloads only what's missing, so the browser set is always correct regardless of cache freshness. The cache still restores chromium for speed; correctness no longer depends on it.

## Verification
This PR's own CI run is the verification — it must reach a green `build-and-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)